### PR TITLE
feat(config): make outputting query functions optional

### DIFF
--- a/src/contract/__test_assets__/codegen.sql.only-types.yml
+++ b/src/contract/__test_assets__/codegen.sql.only-types.yml
@@ -8,4 +8,3 @@ queries:
   - '!src/**/*.test.integration.ts'
 generates:
   types: src/generated/fromSql/types.ts
-  queryFunctions: src/generated/fromSql/queryFunctions.ts

--- a/src/contract/commands/generate.test.integration.ts
+++ b/src/contract/commands/generate.test.integration.ts
@@ -1,7 +1,10 @@
 import SqlCodeGenerator from './generate';
 
 describe('generate', () => {
-  it('should be able to generate code for valid config and sql', async () => {
+  it('should be able to generate code for valid config and sql, generating both types and query functions', async () => {
     await SqlCodeGenerator.run(['-c', `${__dirname}/../__test_assets__/codegen.sql.yml`]);
+  });
+  it('should be able to generate code for valid config and sql, only generating types', async () => {
+    await SqlCodeGenerator.run(['-c', `${__dirname}/../__test_assets__/codegen.sql.only-types.yml`]);
   });
 });

--- a/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/QueryFunctionsOutputPathNotDefinedError.ts
+++ b/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/QueryFunctionsOutputPathNotDefinedError.ts
@@ -1,0 +1,10 @@
+export class QueryFunctionsOutputPathNotDefinedButRequiredError extends Error {
+  constructor() {
+    super(
+      `Query Functions output path was not defined in config (config.generated.queryFunctions) but is required.
+
+      This code path should not have been run as omitting the output path in the config is a signal that the user does not want QueryFunctions defined. Therefore, this is an unexpected error from the library.
+      `,
+    );
+  }
+}

--- a/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/defineTypescriptImportGeneratedTypesCodeForQueryFunctions.ts
+++ b/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/defineTypescriptImportGeneratedTypesCodeForQueryFunctions.ts
@@ -1,5 +1,6 @@
-import { TypeDefinitionOfQuery, GeneratedOutputPaths } from '../../../../model';
+import { GeneratedOutputPaths, TypeDefinitionOfQuery } from '../../../../model';
 import { defineTypescriptQueryFunctionForQuery } from '../../../typeDefinitionsToCode/query/defineTypescriptQueryFunctionForQuery';
+import { QueryFunctionsOutputPathNotDefinedButRequiredError } from './QueryFunctionsOutputPathNotDefinedError';
 import { getRelativePathFromFileToFile } from './utils/getRelativePathFromFileToFile';
 
 export const defineTypescriptImportGeneratedTypesCodeForQueryFunctions = ({
@@ -9,6 +10,9 @@ export const defineTypescriptImportGeneratedTypesCodeForQueryFunctions = ({
   queryDefinitions: TypeDefinitionOfQuery[];
   generatedOutputPaths: GeneratedOutputPaths;
 }) => {
+  // check that the query functions output path was defined; if it was not, this code path should not have been called so fail fast
+  if (!generatedOutputPaths.queryFunctions) throw new QueryFunctionsOutputPathNotDefinedButRequiredError();
+
   // define all of the imports needed
   const generatedTypesToImport = queryDefinitions
     .map((def) => defineTypescriptQueryFunctionForQuery({ name: def.name }).imports.generatedTypes)

--- a/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/defineTypescriptImportQuerySqlCodeForQueryFunctions.ts
+++ b/src/logic/commands/generate/defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions/defineTypescriptImportQuerySqlCodeForQueryFunctions.ts
@@ -1,5 +1,6 @@
 import { TypeDefinitionOfQuery, GeneratedOutputPaths } from '../../../../model';
 import { defineTypescriptQueryFunctionForQuery } from '../../../typeDefinitionsToCode/query/defineTypescriptQueryFunctionForQuery';
+import { QueryFunctionsOutputPathNotDefinedButRequiredError } from './QueryFunctionsOutputPathNotDefinedError';
 import { getRelativePathFromFileToFile } from './utils/getRelativePathFromFileToFile';
 
 const defineTypescriptImportQuerySqlCodeForAQueryFunction = ({
@@ -9,6 +10,9 @@ const defineTypescriptImportQuerySqlCodeForAQueryFunction = ({
   definition: TypeDefinitionOfQuery;
   generatedOutputPaths: GeneratedOutputPaths; // to find the relative path from here to the sql declaration file path
 }) => {
+  // check that the query functions output path was defined; if it was not, this code path should not have been called so fail fast
+  if (!generatedOutputPaths.queryFunctions) throw new QueryFunctionsOutputPathNotDefinedButRequiredError();
+
   // determine the path from the generated code to the query sql export
   const relativePathToExport = getRelativePathFromFileToFile({
     fromFile: generatedOutputPaths.queryFunctions,

--- a/src/logic/commands/generate/generate.ts
+++ b/src/logic/commands/generate/generate.ts
@@ -6,36 +6,40 @@ import { defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions } from './def
 import { extractTypeDefinitionsFromDeclarations } from './extractTypeDefinitionsFromDeclarations/extractTypeDefinitionsFromDeclarations';
 
 export const generate = async ({ configPath }: { configPath: string }) => {
-  // 1. read the declarations from config
+  //  read the declarations from config
   const config = await readConfig({ filePath: configPath });
 
-  // 2. get type definitions for each resource and query
+  // get type definitions for each resource and query
   console.log(chalk.bold('Parsing sql and extracting type definitions...\n')); // tslint:disable-line no-console
   const definitions = extractTypeDefinitionsFromDeclarations({
     language: config.language,
     declarations: config.declarations,
   });
 
-  // 3. get the typescript types code and client methods code
-  console.log(chalk.bold('Generating types and query functions code...\n')); // tslint:disable-line no-console
+  // begin generating the output code files
+  console.log(chalk.bold('Generating code...\n')); // tslint:disable-line no-console
+
+  // output the type definitions code
   const typescriptTypesFileCode = defineTypescriptTypesFileCodeFromTypeDefinitions({
     definitions,
   });
-  const typescriptQueryFunctionsFileCode = defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions({
-    definitions,
-    language: config.language,
-    generatedOutputPaths: config.generates,
-  });
-
-  // 4. output them to desired files
   await saveCode({
     rootDir: config.rootDir,
     filePath: config.generates.types,
     code: typescriptTypesFileCode,
   });
-  await saveCode({
-    rootDir: config.rootDir,
-    filePath: config.generates.queryFunctions,
-    code: typescriptQueryFunctionsFileCode,
-  });
+
+  // output the query functions (if requested)
+  if (config.generates.queryFunctions) {
+    const typescriptQueryFunctionsFileCode = defineTypescriptQueryFunctionsFileCodeFromTypeDefinitions({
+      definitions,
+      language: config.language,
+      generatedOutputPaths: config.generates,
+    });
+    await saveCode({
+      rootDir: config.rootDir,
+      filePath: config.generates.queryFunctions,
+      code: typescriptQueryFunctionsFileCode,
+    });
+  }
 };

--- a/src/logic/config/getConfig/readConfig/readConfig.ts
+++ b/src/logic/config/getConfig/readConfig/readConfig.ts
@@ -1,7 +1,7 @@
-import { readYmlFile } from './utils/readYmlFile';
 import { GeneratorConfig } from '../../../../model';
 import { getAllPathsMatchingGlobs } from '../getAllPathsMatchingGlobs/getAllPathsMatchingGlobs';
-import { extractDeclarationFromGlobedFile, DeclarationType } from './extractDeclarationFromGlobedFile';
+import { DeclarationType, extractDeclarationFromGlobedFile } from './extractDeclarationFromGlobedFile';
+import { readYmlFile } from './utils/readYmlFile';
 
 /*
   1. read the yml file
@@ -20,9 +20,6 @@ export const readConfig = async ({ filePath }: { filePath: string }) => {
   // get the output dir
   if (!contents.generates) throw new Error('generates key must be defined');
   if (!contents.generates.types) throw new Error('generates.types must specify where to output the generated types');
-  if (!contents.generates.queryFunctions) {
-    throw new Error('generates.queryFunctions must specify where to output the query functions');
-  }
 
   // get the language and dialect
   if (!contents.language) throw new Error('language must be defined');

--- a/src/model/constants.ts
+++ b/src/model/constants.ts
@@ -41,5 +41,5 @@ export type TypeDefinition =
   | TypeDefinitionOfResourceView;
 export interface GeneratedOutputPaths {
   types: string;
-  queryFunctions: string;
+  queryFunctions: string | undefined; // undefined -> user does not want them
 }

--- a/src/model/valueObjects/GeneratorConfig.ts
+++ b/src/model/valueObjects/GeneratorConfig.ts
@@ -10,7 +10,7 @@ const generatorConfigSchema = Joi.object().keys({
   dialect: Joi.string().required(),
   generates: Joi.object().keys({
     types: Joi.string().required(),
-    queryFunctions: Joi.string().required(),
+    queryFunctions: Joi.string().optional(),
   }),
   declarations: Joi.array().items(QueryDeclaration.schema, ResourceDeclaration.schema),
 });


### PR DESCRIPTION
closes https://github.com/uladkasach/sql-code-generator/issues/33

if the `config.generates.queryFunctions` argument is not present, these will no longer get created

#### case 1:

```yml
# config.yml
language: mysql
dialect: 5.7
resources:
  - 'schema/**/*.sql'
queries:
  - 'src/dao/**/*.ts'
  - '!src/**/*.test.ts'
  - '!src/**/*.test.integration.ts'
generates:
  types: src/generated/fromSql/types.ts
  queryFunctions: src/generated/fromSql/queryFunctions.ts
```
```sh
Parsing sql and extracting type definitions...

Generating code...

  ✔ [GENERATED] src/generated/fromSql/types.ts
  ✔ [GENERATED] src/generated/fromSql/queryFunctions.ts
```

#### case 2:

```yml
# config.yml
language: mysql
dialect: 5.7
resources:
  - 'schema/**/*.sql'
queries:
  - 'src/dao/**/*.ts'
  - '!src/**/*.test.ts'
  - '!src/**/*.test.integration.ts'
generates:
  types: src/generated/fromSql/types.ts
```
```sh
Parsing sql and extracting type definitions...

Generating code...

  ✔ [GENERATED] src/generated/fromSql/types.ts
```