### PR TITLE
feat(subquery): support input variables in subqueries

### DIFF
--- a/src/contract/__test_assets__/codegen.sql.yml
+++ b/src/contract/__test_assets__/codegen.sql.yml
@@ -1,11 +1,11 @@
 language: mysql
 dialect: 5.7
 resources:
-  - "schema/**/*.sql"
+  - 'schema/**/*.sql'
 queries:
-  - "src/dao/**/*.ts"
-  - "!src/**/*.test.ts"
-  - "!src/**/*.test.integration.ts"
+  - 'src/dao/**/*.ts'
+  - '!src/**/*.test.ts'
+  - '!src/**/*.test.integration.ts'
 generates:
   types: src/generated/fromSql/types.ts
   queryFunctions: src/generated/fromSql/queryFunctions.ts

--- a/src/contract/__test_assets__/schema/functions/upsert_home.sql
+++ b/src/contract/__test_assets__/schema/functions/upsert_home.sql
@@ -1,0 +1,30 @@
+CREATE FUNCTION `upsert_home`(
+  in_user_id varchar(190),
+  in_address varchar(190)
+) RETURNS bigint(20)
+BEGIN
+  -- declarations
+  DECLARE v_static_id BIGINT;
+  DECLARE v_created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6); -- define a common created_at timestamp to use
+
+  -- find or create the static entity
+  SET v_static_id = (
+    SELECT id
+    FROM image
+    WHERE 1=1
+      AND (user_id = BINARY in_user_id)
+      AND (address = BINARY in_address)
+  );
+  IF (v_static_id IS NULL) THEN -- if entity could not be found originally, create the static entity
+    INSERT INTO image
+      (uuid, created_at, user_id, address)
+      VALUES
+      (uuid(), v_created_at, in_user_id, in_address)
+    SET v_static_id = (
+      SELECT last_insert_id()
+    );
+  END IF;
+
+  -- return the static entity id
+  return v_static_id;
+END

--- a/src/contract/__test_assets__/schema/tables/home.sql
+++ b/src/contract/__test_assets__/schema/tables/home.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `home` (
+  -- meta
+  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `uuid` VARCHAR(36) NOT NULL,
+  `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+  -- static data (in this example... in real life this should not be static)
+  `address` VARCHAR(255) NOT NULL, -- in this example, an address is just a string
+  `user_id` VARCHAR(255) NOT NULL, -- in this example, homes can never change hands
+
+  -- meta meta
+  UNIQUE (`address`),
+  CONSTRAINT home_fk_1 FOREIGN KEY (user_id) REFERENCES user(id)
+) ENGINE = InnoDB;

--- a/src/contract/__test_assets__/src/dao/home/upsertHome.ts
+++ b/src/contract/__test_assets__/src/dao/home/upsertHome.ts
@@ -1,0 +1,7 @@
+export const sql = `
+-- query_name = upsert_home
+SELECT upsert_home(
+  (select u.id from user u where u.uuid = :userUuid), -- lookup user id for fk by uuid
+  :address
+) as id;
+`.trim();

--- a/src/logic/__test_assets__/queries/find_providers_with_work_count.sql
+++ b/src/logic/__test_assets__/queries/find_providers_with_work_count.sql
@@ -1,0 +1,7 @@
+SELECT
+  p.id,
+  p.uuid,
+  (
+    SELECT count(1) from work w where w.providerUuid = p.uuid
+  ) as work_count
+FROM provider p

--- a/src/logic/__test_assets__/queries/upsert_profile_with_subquery_function.sql
+++ b/src/logic/__test_assets__/queries/upsert_profile_with_subquery_function.sql
@@ -1,0 +1,7 @@
+  -- query_name = upsert_provider_profile
+  SELECT upsert_provider_profile(
+    (SELECT get_provider_id_by_uuid(:providerUuid)),
+    :bannerImageUuid,
+    :pictureImageUuid,
+    :introduction
+  ) as id;

--- a/src/logic/__test_assets__/queries/upsert_profile_with_subselect.sql
+++ b/src/logic/__test_assets__/queries/upsert_profile_with_subselect.sql
@@ -1,0 +1,7 @@
+  -- query_name = upsert_provider_profile
+  SELECT upsert_provider_profile(
+    (SELECT p.id FROM view_provider_current p WHERE p.uuid = :serviceProviderUuid),
+    :bannerImageUuid,
+    :pictureImageUuid,
+    :introduction
+  ) as id;

--- a/src/logic/sqlToTypeDefinitions/query/__snapshots__/extractTypeDefinitionFromQuerySql.test.ts.snap
+++ b/src/logic/sqlToTypeDefinitions/query/__snapshots__/extractTypeDefinitionFromQuerySql.test.ts.snap
@@ -113,6 +113,58 @@ TypeDefinitionOfQuery {
 }
 `;
 
+exports[`extractTypeDefinitionFromQuerySql should be able to determine types accurately an upsert query which includes a subquery 1`] = `
+TypeDefinitionOfQuery {
+  "inputVariables": Array [
+    TypeDefinitionOfQueryInputVariable {
+      "name": "serviceProviderUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": null,
+        "tableReferencePath": "p.uuid",
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "bannerImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.1",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "pictureImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.2",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "introduction",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.3",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "name": "upsert_profile_with_subselect",
+  "path": "__PATH__",
+  "selectExpressions": Array [
+    TypeDefinitionOfQuerySelectExpression {
+      "alias": "id",
+      "typeReference": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.output",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "tableReferences": Array [
+    TypeDefinitionOfQueryTableReference {
+      "alias": "p",
+      "tableName": "view_provider_current",
+    },
+  ],
+}
+`;
+
 exports[`extractTypeDefinitionFromQuerySql should be able to determine types accurately for a query with a postgres fn in the select expressions (as well as subselect) 1`] = `
 TypeDefinitionOfQuery {
   "inputVariables": Array [
@@ -211,6 +263,10 @@ TypeDefinitionOfQuery {
       "alias": "v",
       "tableName": "job_version",
     },
+    TypeDefinitionOfQueryTableReference {
+      "alias": "job_version_to_photo",
+      "tableName": "job_version_to_photo",
+    },
   ],
 }
 `;
@@ -299,6 +355,10 @@ TypeDefinitionOfQuery {
     TypeDefinitionOfQueryTableReference {
       "alias": "s",
       "tableName": "ice_cream",
+    },
+    TypeDefinitionOfQueryTableReference {
+      "alias": "ice_cream_to_ingredient",
+      "tableName": "ice_cream_to_ingredient",
     },
   ],
 }

--- a/src/logic/sqlToTypeDefinitions/query/__snapshots__/extractTypeDefinitionFromQuerySql.test.ts.snap
+++ b/src/logic/sqlToTypeDefinitions/query/__snapshots__/extractTypeDefinitionFromQuerySql.test.ts.snap
@@ -113,58 +113,6 @@ TypeDefinitionOfQuery {
 }
 `;
 
-exports[`extractTypeDefinitionFromQuerySql should be able to determine types accurately an upsert query which includes a subquery 1`] = `
-TypeDefinitionOfQuery {
-  "inputVariables": Array [
-    TypeDefinitionOfQueryInputVariable {
-      "name": "serviceProviderUuid",
-      "type": TypeDefinitionReference {
-        "functionReferencePath": null,
-        "tableReferencePath": "p.uuid",
-      },
-    },
-    TypeDefinitionOfQueryInputVariable {
-      "name": "bannerImageUuid",
-      "type": TypeDefinitionReference {
-        "functionReferencePath": "upsert_provider_profile.input.1",
-        "tableReferencePath": null,
-      },
-    },
-    TypeDefinitionOfQueryInputVariable {
-      "name": "pictureImageUuid",
-      "type": TypeDefinitionReference {
-        "functionReferencePath": "upsert_provider_profile.input.2",
-        "tableReferencePath": null,
-      },
-    },
-    TypeDefinitionOfQueryInputVariable {
-      "name": "introduction",
-      "type": TypeDefinitionReference {
-        "functionReferencePath": "upsert_provider_profile.input.3",
-        "tableReferencePath": null,
-      },
-    },
-  ],
-  "name": "upsert_profile_with_subselect",
-  "path": "__PATH__",
-  "selectExpressions": Array [
-    TypeDefinitionOfQuerySelectExpression {
-      "alias": "id",
-      "typeReference": TypeDefinitionReference {
-        "functionReferencePath": "upsert_provider_profile.output",
-        "tableReferencePath": null,
-      },
-    },
-  ],
-  "tableReferences": Array [
-    TypeDefinitionOfQueryTableReference {
-      "alias": "p",
-      "tableName": "view_provider_current",
-    },
-  ],
-}
-`;
-
 exports[`extractTypeDefinitionFromQuerySql should be able to determine types accurately for a query with a postgres fn in the select expressions (as well as subselect) 1`] = `
 TypeDefinitionOfQuery {
   "inputVariables": Array [
@@ -529,5 +477,104 @@ TypeDefinitionOfQuery {
       "tableName": "suggestion_version",
     },
   ],
+}
+`;
+
+exports[`extractTypeDefinitionFromQuerySql subqueries should be able to determine types accurately an upsert query which includes a subquery 1`] = `
+TypeDefinitionOfQuery {
+  "inputVariables": Array [
+    TypeDefinitionOfQueryInputVariable {
+      "name": "serviceProviderUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": null,
+        "tableReferencePath": "p.uuid",
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "bannerImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.1",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "pictureImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.2",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "introduction",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.3",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "name": "upsert_profile_with_subselect",
+  "path": "__PATH__",
+  "selectExpressions": Array [
+    TypeDefinitionOfQuerySelectExpression {
+      "alias": "id",
+      "typeReference": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.output",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "tableReferences": Array [
+    TypeDefinitionOfQueryTableReference {
+      "alias": "p",
+      "tableName": "view_provider_current",
+    },
+  ],
+}
+`;
+
+exports[`extractTypeDefinitionFromQuerySql subqueries should be able to determine types accurately an upsert query which includes a subquery which calls a function 1`] = `
+TypeDefinitionOfQuery {
+  "inputVariables": Array [
+    TypeDefinitionOfQueryInputVariable {
+      "name": "providerUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "get_provider_id_by_uuid.input.0",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "bannerImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.1",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "pictureImageUuid",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.2",
+        "tableReferencePath": null,
+      },
+    },
+    TypeDefinitionOfQueryInputVariable {
+      "name": "introduction",
+      "type": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.input.3",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "name": "upsert_profile_with_subquery_function",
+  "path": "__PATH__",
+  "selectExpressions": Array [
+    TypeDefinitionOfQuerySelectExpression {
+      "alias": "id",
+      "typeReference": TypeDefinitionReference {
+        "functionReferencePath": "upsert_provider_profile.output",
+        "tableReferencePath": null,
+      },
+    },
+  ],
+  "tableReferences": Array [],
 }
 `;

--- a/src/logic/sqlToTypeDefinitions/query/common/flattenSqlByReferencingAndTokenizingSubqueries/extractAndTokenizeSubqueryReferencesInArrayOfSqlStrings.ts
+++ b/src/logic/sqlToTypeDefinitions/query/common/flattenSqlByReferencingAndTokenizingSubqueries/extractAndTokenizeSubqueryReferencesInArrayOfSqlStrings.ts
@@ -11,7 +11,10 @@ export const extractAndTokenizeSubqueryReferencesInArrayOfSqlStrings = ({ sqlPar
     const matchesQueryPattern = new RegExp(/^\(\s*select(?:.|\s)*\)$/i).test(sql);
     // if it matches the pattern for being a "query", then return swap it out with a reference
     if (matchesQueryPattern) {
-      const reference = new SqlSubqueryReference({ id: uuid(), sql });
+      const reference = new SqlSubqueryReference({
+        id: uuid().replace(/-/g, ''), // uuid without dashes, important for downstream logic
+        sql,
+      });
       references.push(reference);
       return getTokenForSqlSubqueryReference({ reference });
     }

--- a/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/__snapshots__/extractInputVariablesFromQuerySql.test.ts.snap
+++ b/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/__snapshots__/extractInputVariablesFromQuerySql.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`extractSelectExpressionsFromQuerySql should be able to determine types accurately for a case where an input variable is defined in a subquery used as an input to a function 1`] = `
+Array [
+  TypeDefinitionOfQueryInputVariable {
+    "name": "serviceProviderUuid",
+    "type": TypeDefinitionReference {
+      "functionReferencePath": null,
+      "tableReferencePath": "p.uuid",
+    },
+  },
+  TypeDefinitionOfQueryInputVariable {
+    "name": "bannerImageUuid",
+    "type": TypeDefinitionReference {
+      "functionReferencePath": "upsert_provider_profile.input.1",
+      "tableReferencePath": null,
+    },
+  },
+  TypeDefinitionOfQueryInputVariable {
+    "name": "pictureImageUuid",
+    "type": TypeDefinitionReference {
+      "functionReferencePath": "upsert_provider_profile.input.2",
+      "tableReferencePath": null,
+    },
+  },
+  TypeDefinitionOfQueryInputVariable {
+    "name": "introduction",
+    "type": TypeDefinitionReference {
+      "functionReferencePath": "upsert_provider_profile.input.3",
+      "tableReferencePath": null,
+    },
+  },
+]
+`;
+
 exports[`extractSelectExpressionsFromQuerySql should be able to determine types accurately for this example 1`] = `
 Array [
   TypeDefinitionOfQueryInputVariable {

--- a/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractInputVariablesFromQuerySql.test.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractInputVariablesFromQuerySql.test.ts
@@ -34,4 +34,13 @@ describe('extractSelectExpressionsFromQuerySql', () => {
     expect(defs.length).toEqual(1);
     expect(defs).toMatchSnapshot();
   });
+  it('should be able to determine types accurately for a case where an input variable is defined in a subquery used as an input to a function', async () => {
+    const sql = await extractSqlFromFile({
+      filePath: `${__dirname}/../../../__test_assets__/queries/upsert_profile_with_subselect.sql`,
+    });
+    const defs = extractInputVariablesFromQuerySql({ sql });
+
+    expect(defs.length).toEqual(4);
+    expect(defs).toMatchSnapshot();
+  });
 });

--- a/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractInputVariablesFromQuerySql.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractInputVariablesFromQuerySql.ts
@@ -1,29 +1,46 @@
-/*
-  goal:
-  - try to define input type when possible
-  - fallback to "any" when not possible and ask user to add an issue w/ use case when this occurs
-    - so that the generator is non-blocking
+import strip from 'sql-strip-comments';
 
-  e.g.,:
-    - where u.id = :id => "{ id: number }"
-    - where lower(u.name) = :name => { name: any } (for mvp);
-      - later, { name: string } (since we'd track standard fn's; TODO)
-
-  steps:
-    - 1. find all of the `:__variable_name__` pattern input definitions (yesql format)
-    - 2. attempt to figure out the type for each variable name
-*/
-
+import { flattenSqlByReferencingAndTokenizingSubqueries } from '../common/flattenSqlByReferencingAndTokenizingSubqueries';
 import { extractInputVariableTokensFromQuerySql } from './extractInputVariableTokensFromQuerySql';
 import { extractTypeDefinitionFromInputVariableSql } from './extractTypeDefinitionFromInputVariableSql';
 
+/**
+ * goal:
+ *  - try to define input type when possible
+ * - fallback to "any" when not possible and ask user to add an issue w/ use case when this occurs
+ *   - so that the generator is non-blocking
+ *
+ *  e.g.,:
+ *   - where u.id = :id => "{ id: number }"
+ *   - where lower(u.name) = :name => { name: any } (for mvp);
+ *     - later, { name: string } (since we'd track standard fn's; TODO)
+ *
+ * steps:
+ * - 1. find all of the `:__variable_name__` pattern input definitions (yesql format)
+ * - 2. attempt to figure out the type for each variable name
+ */
+
 export const extractInputVariablesFromQuerySql = ({ sql }: { sql: string }) => {
-  // 1. find each input variable that needs to have a type def defined
+  // find each input variable that needs to have a type def defined
   const inputVariableTokens = extractInputVariableTokensFromQuerySql({ sql });
 
-  // 2. define the type definition for each variable
-  const definitions = inputVariableTokens.map((token) => extractTypeDefinitionFromInputVariableSql({ token, sql }));
+  // flatten the sql, to avoid subquery syntax interfering with below search patterns
+  const strippedSql = strip(sql);
+  const { flattenedSql, references: subqueries } = flattenSqlByReferencingAndTokenizingSubqueries({
+    sql: strippedSql,
+  });
 
-  // 3. return defs
+  // define the type definition for each variable
+  const definitions = inputVariableTokens.map((token) => {
+    // check if the token is actually in a subquery; run it on the subquery if so
+    const foundSubqueryContainingToken = subqueries.find((subquery) => subquery.sql.includes(token));
+    if (foundSubqueryContainingToken)
+      return extractTypeDefinitionFromInputVariableSql({ token, sql: foundSubqueryContainingToken.sql });
+
+    // otherwise, run it on the root flattened query (flattened to make sure subquery syntax does not cause problems)
+    return extractTypeDefinitionFromInputVariableSql({ token, sql: flattenedSql });
+  });
+
+  // return defs
   return definitions;
 };

--- a/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractTypeDefinitionFromInputVariableSql.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractInputVariablesFromQuerySql/extractTypeDefinitionFromInputVariableSql.ts
@@ -3,7 +3,13 @@ import { throwErrorIfTableReferencePathImpliesTable } from '../common/throwError
 import { TypeDefinitionReference } from '../../../../model/valueObjects/TypeDefinitionReference';
 import { DataType } from '../../../../model';
 
-export const extractTypeDefinitionFromInputVariableSql = ({ token, sql }: { token: string; sql: string }) => {
+export const extractTypeDefinitionFromInputVariableSql = ({
+  token,
+  sql,
+}: {
+  token: string;
+  sql: string;
+}): TypeDefinitionOfQueryInputVariable => {
   // 1. check if this token matches the "resource.column = :token" pattern; if so, then the input type = the resource.column type
   const [
     _, // tslint:disable-line no-unused

--- a/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/__snapshots__/extractTableReferencesFromQuerySql.test.ts.snap
+++ b/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/__snapshots__/extractTableReferencesFromQuerySql.test.ts.snap
@@ -17,6 +17,19 @@ Array [
 ]
 `;
 
+exports[`extractTableReferencesFromQuerySql should be able to determine types accurately for an example with subqueries referencing their own tables 1`] = `
+Array [
+  TypeDefinitionOfQueryTableReference {
+    "alias": "p",
+    "tableName": "provider",
+  },
+  TypeDefinitionOfQueryTableReference {
+    "alias": "w",
+    "tableName": "work",
+  },
+]
+`;
+
 exports[`extractTableReferencesFromQuerySql should be able to determine types accurately for this example 1`] = `
 Array [
   TypeDefinitionOfQueryTableReference {

--- a/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/extractTableReferencesFromQuerySql.test.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/extractTableReferencesFromQuerySql.test.ts
@@ -28,4 +28,13 @@ describe('extractTableReferencesFromQuerySql', () => {
     );
     expect(defs).toMatchSnapshot();
   });
+  it('should be able to determine types accurately for an example with subqueries referencing their own tables', async () => {
+    const sql = await extractSqlFromFile({
+      filePath: `${__dirname}/../../../__test_assets__/queries/find_providers_with_work_count.sql`,
+    });
+    const defs = extractTableReferencesFromQuerySql({ sql });
+    expect(defs.length).toEqual(2);
+    expect(defs).toContainEqual(new TypeDefinitionOfQueryTableReference({ alias: 'w', tableName: 'work' })); // has the subqueries definition
+    expect(defs).toMatchSnapshot();
+  });
 });

--- a/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/extractTableReferencesFromQuerySql.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractTableReferencesFromQuerySql/extractTableReferencesFromQuerySql.ts
@@ -3,12 +3,23 @@ import { tryToExtractTableReferenceSqlSet } from './tryToExtractTableReferenceSq
 import { flattenSqlByReferencingAndTokenizingSubqueries } from '../common/flattenSqlByReferencingAndTokenizingSubqueries';
 
 export const extractTableReferencesFromQuerySql = ({ sql }: { sql: string }) => {
-  // 0. tokenize each subquery
-  const { flattenedSql } = flattenSqlByReferencingAndTokenizingSubqueries({ sql }); // flatten the sql - so that subqueries don't hinder regular parsing
+  // flatten the sql and tokenize each subquery - otherwise subquery syntax throws off subsequent processing
+  const { flattenedSql: rootQuerySql, references: subqueries } = flattenSqlByReferencingAndTokenizingSubqueries({
+    sql,
+  });
 
-  // 1. get the table reference sqls from the query sql
-  const tableReferenceSqlSet = tryToExtractTableReferenceSqlSet({ sql: flattenedSql }); // "try to", since its okay if there are no table references; (e.g., `select upsert_something(...)`)
+  // on both the root query sql and each subquery sql (if subqueries are present) extract table references
+  const flattenedSqlsToConsider = [rootQuerySql, ...subqueries.map((subquery) => subquery.sql)];
+  const tableReferences = flattenedSqlsToConsider
+    .map((sql) => {
+      // get the table reference sqls from the main query sql
+      const tableReferenceSqlSet = tryToExtractTableReferenceSqlSet({ sql }); // "try to", since its okay if there are no table references; (e.g., `select upsert_something(...)`)
 
-  // 2. get the type definitions of table references from each table reference sql
-  return tableReferenceSqlSet.map((sql) => extractTypeDefinitionFromTableReference({ sql }));
+      // get the type definitions of table references from each table reference sql
+      return tableReferenceSqlSet.map((sql) => extractTypeDefinitionFromTableReference({ sql }));
+    })
+    .flat();
+
+  // return the table references
+  return tableReferences;
 };

--- a/src/logic/sqlToTypeDefinitions/query/extractTypeDefinitionFromQuerySql.test.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractTypeDefinitionFromQuerySql.test.ts
@@ -84,16 +84,30 @@ describe('extractTypeDefinitionFromQuerySql', () => {
     expect(defs.inputVariables.length).toEqual(1);
     expect(defs).toMatchSnapshot();
   });
-  it('should be able to determine types accurately an upsert query which includes a subquery', async () => {
-    const sql = await extractSqlFromFile({
-      filePath: `${__dirname}/../../__test_assets__/queries/upsert_profile_with_subselect.sql`,
+  describe('subqueries', () => {
+    it('should be able to determine types accurately an upsert query which includes a subquery', async () => {
+      const sql = await extractSqlFromFile({
+        filePath: `${__dirname}/../../__test_assets__/queries/upsert_profile_with_subselect.sql`,
+      });
+      const defs = extractTypeDefinitionFromQuerySql({
+        name: 'upsert_profile_with_subselect',
+        path: '__PATH__',
+        sql,
+      });
+      expect(defs.tableReferences.length).toBeGreaterThan(0); // should have a table reference to the table in the subquery
+      expect(defs).toMatchSnapshot();
     });
-    const defs = extractTypeDefinitionFromQuerySql({
-      name: 'upsert_profile_with_subselect',
-      path: '__PATH__',
-      sql,
+    it('should be able to determine types accurately an upsert query which includes a subquery which calls a function', async () => {
+      const sql = await extractSqlFromFile({
+        filePath: `${__dirname}/../../__test_assets__/queries/upsert_profile_with_subquery_function.sql`,
+      });
+      const defs = extractTypeDefinitionFromQuerySql({
+        name: 'upsert_profile_with_subquery_function',
+        path: '__PATH__',
+        sql,
+      });
+      expect(defs.tableReferences.length).toEqual(0); // no table references, only function references
+      expect(defs).toMatchSnapshot();
     });
-    expect(defs.tableReferences.length).toBeGreaterThan(0); // should have a table reference to the table in the subquery
-    expect(defs).toMatchSnapshot();
   });
 });

--- a/src/logic/sqlToTypeDefinitions/query/extractTypeDefinitionFromQuerySql.test.ts
+++ b/src/logic/sqlToTypeDefinitions/query/extractTypeDefinitionFromQuerySql.test.ts
@@ -84,4 +84,16 @@ describe('extractTypeDefinitionFromQuerySql', () => {
     expect(defs.inputVariables.length).toEqual(1);
     expect(defs).toMatchSnapshot();
   });
+  it('should be able to determine types accurately an upsert query which includes a subquery', async () => {
+    const sql = await extractSqlFromFile({
+      filePath: `${__dirname}/../../__test_assets__/queries/upsert_profile_with_subselect.sql`,
+    });
+    const defs = extractTypeDefinitionFromQuerySql({
+      name: 'upsert_profile_with_subselect',
+      path: '__PATH__',
+      sql,
+    });
+    expect(defs.tableReferences.length).toBeGreaterThan(0); // should have a table reference to the table in the subquery
+    expect(defs).toMatchSnapshot();
+  });
 });

--- a/src/logic/sqlToTypeDefinitions/resource/view/__snapshots__/extractTypeDefinitionFromViewSql.test.ts.snap
+++ b/src/logic/sqlToTypeDefinitions/resource/view/__snapshots__/extractTypeDefinitionFromViewSql.test.ts.snap
@@ -286,6 +286,10 @@ TypeDefinitionOfResourceView {
       "alias": "v",
       "tableName": "job_version",
     },
+    TypeDefinitionOfQueryTableReference {
+      "alias": "job_version_to_photo",
+      "tableName": "job_version_to_photo",
+    },
   ],
 }
 `;

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,8 @@
     "ter-arrow-parens": false,
     "member-ordering": false,
     "ter-indent": false,
-    "array-type": false
+    "array-type": false,
+    "curly": false
   },
   "linterOptions": {
     "exclude": ["src/logic/__test_assets__/exampleProject/postgres/src/generated/fromSql/**/*"]


### PR DESCRIPTION
closes https://github.com/uladkasach/sql-code-generator/issues/4 

it handles cases `b` and `c` outlined in the comments of that issue. however, because case `b` is functionally equivalent to case `a` - this ends up handling all of the requirements. 

i.e.,:
```sql
SELECT upsert_profile(
  get_provider_id_from_uuid(:providerUuid),
  :introduction,
  ...
)
```

is functionally equivalent to
```sql
SELECT upsert_profile(
  (SELECT get_provider_id_from_uuid(:providerUuid)),
  :introduction,
  ...
)
```

we may eventually support that first variant - but this gets us 100% of the functionality and 80% of the syntax with 20% of the work